### PR TITLE
Fix capitalization mistake.

### DIFF
--- a/docs/user_guide/gotchas.rst
+++ b/docs/user_guide/gotchas.rst
@@ -90,7 +90,7 @@ To achieve the desired result the step function should be clipped to the require
     year2021 = (pd.Timestamp("2021"), pd.Timestamp("2022"))
     (sf1 > sf2).clip(*year2021).mean()
 
-or, perhaps preferably, the original step functions are clipped intially:
+Or, perhaps preferably, the original step functions are clipped intially:
 
 .. ipython:: python
 


### PR DESCRIPTION
Capitalized the letter 'o' in 'Or' as it is at the beginning of a sentence.

- [x] closes #102
- [x] tests added / passed
- [x] ensure all linting tests pass
- [x] changelog entry
