### PR TITLE
bugfix for incorrect closed parameter not being produced by operation…

### DIFF
--- a/docs/release_notes/changelog.rst
+++ b/docs/release_notes/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 
 UNRELEASED
 
+- bugfix for layer function when using pandas Series with different index (#GH112)
 
 Please list new changes above this comment
 

--- a/staircase/core/layering.py
+++ b/staircase/core/layering.py
@@ -97,8 +97,12 @@ def layer(self, start=None, end=None, value=None, frame=None):
     assert not pd.isna(value).any(), "value parameter cannot contain null values"
     if not isinstance(start, pd.Series):
         start = pd.Series(start)
+    else:
+        start = start.reset_index(drop=True)
     if not isinstance(end, pd.Series):
         end = pd.Series(end)
+    else:
+        end = end.reset_index(drop=True)
     df = pd.concat([start, end], axis=1, ignore_index=True)
     start_series = pd.Series(value, index=df.iloc[:, 0])
     self.initial_value += start_series[start_series.index.isna()].sum()

--- a/tests/test_floats/test_floats_construction.py
+++ b/tests/test_floats/test_floats_construction.py
@@ -334,3 +334,19 @@ def test_layering_frame(s1_fix):
 
 def test_layering_trivial_1(s1_fix):
     assert s1_fix.copy().layer(1, 1).identical(s1_fix)
+
+def test_layering_series_with_different_index():
+    #GH112
+    result = Stairs(
+        start=pd.Series([0,2,4], index=[0,2,4]),
+        end = pd.Series([1,3,5], index=[1,3,5]),
+    )
+    expected = pd.Series([1,0,1,0,1,0])
+    pd.testing.assert_series_equal(
+        result.step_values,
+        expected,
+        check_names=False,
+        check_index_type=False,
+        check_dtype=False,
+    )
+    assert result.initial_value == 0

--- a/tests/test_floats/test_floats_construction.py
+++ b/tests/test_floats/test_floats_construction.py
@@ -335,13 +335,14 @@ def test_layering_frame(s1_fix):
 def test_layering_trivial_1(s1_fix):
     assert s1_fix.copy().layer(1, 1).identical(s1_fix)
 
+
 def test_layering_series_with_different_index():
-    #GH112
+    # GH112
     result = Stairs(
-        start=pd.Series([0,2,4], index=[0,2,4]),
-        end = pd.Series([1,3,5], index=[1,3,5]),
+        start=pd.Series([0, 2, 4], index=[0, 2, 4]),
+        end=pd.Series([1, 3, 5], index=[1, 3, 5]),
     )
-    expected = pd.Series([1,0,1,0,1,0])
+    expected = pd.Series([1, 0, 1, 0, 1, 0])
     pd.testing.assert_series_equal(
         result.step_values,
         expected,


### PR DESCRIPTION
…s with right-closed step functions (#GH95)

- [x] closes #112 
- [ ] tests added / passed
- [ ] ensure all linting tests pass
- [ ] changelog entry
