### PR TITLE
Typo Update in 05_comparing.rst

### DIFF
--- a/docs/getting_started/intro_tutorials/05_comparing.rst
+++ b/docs/getting_started/intro_tutorials/05_comparing.rst
@@ -56,7 +56,7 @@ Logical
 
 Under the assumption that the value 1 is equivalent to *true*, and a value of 0 is equivalent to *false*, then a logical comparison between two boolean step functions (ones whose values are either 0, or 1) is intuitively derived from standard logical comparisons.
 
-To answer the question of "what if the step function is not boolean valued" we appeal to the boolean definition that Python applies to numbers;anything not zero is considered *true*, and consequently only zero is false.
+To answer the question of "what if the step function is not boolean valued" we appeal to the boolean definition that Python applies to numbers: anything not zero is considered *true*, and consequently only zero is false.
 
 Let's see some examples:
 


### PR DESCRIPTION
Below is the changes made to the file in  

 ```diff
- To answer the question of "what if the step function is not boolean valued" we appeal to the boolean definition that Python applies to numbers;anything not zero is considered *true*, and consequently only zero is false.
+To answer the question of "what if the step function is not boolean valued" we appeal to the boolean definition that Python applies to numbers: anything not zero is considered *true*, and consequently only zero is false.
```

<!-- Please note that low quality PRs and PRs that do not follow our contributing guidelines will be marked as invalid for Hacktoberfest. -->

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #99

<!-- Feel free to add any additional description of changes below this line -->

The list of files can be found in below link [link](https://github.com/staircase-dev/staircase/blob/master/docs/getting_started/intro_tutorials/05_comparing.rst)

- [x] closes #99

