### PR TITLE
bugfix for using :meth:`staircase.Stairs.from_values` with timezone a…

### DIFF
--- a/docs/release_notes/changelog.rst
+++ b/docs/release_notes/changelog.rst
@@ -7,6 +7,8 @@ Changelog
 
 UNRELEASED
 
+- bugfix for using :meth:`staircase.Stairs.from_values` with timezone aware DatetimeIndex on `values` argument  (#GH145)
+
 Please list new changes above this comment
 
 **v2.4.1 2022-05-09**

--- a/staircase/core/layering.py
+++ b/staircase/core/layering.py
@@ -16,7 +16,7 @@ from staircase.docstrings import examples
 from staircase.util._decorators import Appender
 
 
-def _check_args_dtypes(start, end):
+def _check_args_dtypes(*vectors):
     approved_dtypes_checks = [
         is_datetime64_any_dtype,
         is_timedelta64_dtype,
@@ -27,11 +27,11 @@ def _check_args_dtypes(start, end):
         approved = any(map(lambda func: func(vec), approved_dtypes_checks))
         if not approved:
             warnings.warn(
-                f"An argument supplied for 'start' or 'end' has dtype {vec.dtype}.  Only numerical, datetime-like, or timedelta dtypes have been tested.  Using other dtypes is considered experimental."
+                f"An argument supplied has dtype {vec.dtype}.  Only numerical, datetime-like, or timedelta dtypes have been tested.  Using other dtypes is considered experimental."
             )
 
-    _check_approved_dtype(start)
-    _check_approved_dtype(end)
+    for vec in vectors:
+        _check_approved_dtype(vec)
 
 
 def _check_args_types(start, end):

--- a/staircase/core/stairs.py
+++ b/staircase/core/stairs.py
@@ -115,7 +115,7 @@ class Stairs:
         ):
             warnings.warn("The index of data is not numeric, or time based")
 
-        if np.isinf(values.index).any():
+        if is_numeric_dtype(values.index) and np.isinf(values.index).any():
             raise ValueError("Invalid value for Series index")
 
         if not is_numeric_dtype(values) or not is_number(initial_value):

--- a/staircase/core/stairs.py
+++ b/staircase/core/stairs.py
@@ -22,6 +22,7 @@ from staircase import docstrings
 from staircase.constants import inf
 from staircase.core import stats
 from staircase.core.accessor import CachedAccessor
+from staircase.core.layering import _check_args_dtypes
 from staircase.plotting.accessor import PlotAccessor
 from staircase.util import _replace_none_with_infs
 from staircase.util._decorators import Appender
@@ -108,12 +109,7 @@ class Stairs:
         if not isinstance(values, pd.Series) or values.empty:
             raise ValueError("values must be a not empty Series")
 
-        if not (
-            is_numeric_dtype(values.index)
-            or is_datetime64_dtype(values.index)
-            or is_timedelta64_dtype(values.index)
-        ):
-            warnings.warn("The index of data is not numeric, or time based")
+        _check_args_dtypes(values.index)
 
         if is_numeric_dtype(values.index) and np.isinf(values.index).any():
             raise ValueError("Invalid value for Series index")

--- a/tests/test_dates/test_dates_misc.py
+++ b/tests/test_dates/test_dates_misc.py
@@ -333,3 +333,26 @@ def test_clip_expected_type(date_func, kwargs):
     kwargs = {key: timestamp(*val, date_func=date_func) for key, val in kwargs.items()}
     result = s1(date_func).clip(**kwargs)
     assert_expected_type(result, date_func)
+
+
+def test_from_values(date_func):
+    # this corresponds to the step function produced by S1 method
+    values = pd.Series(
+        [2, 4.5, 2, -0.5, 0],
+        index=[
+            timestamp(2020, 1, 1, date_func=date_func),
+            timestamp(2020, 1, 3, date_func=date_func),
+            timestamp(2020, 1, 5, date_func=date_func),
+            timestamp(2020, 1, 6, date_func=date_func),
+            timestamp(2020, 1, 10, date_func=date_func),
+        ],
+    )
+
+    sf = Stairs.from_values(
+        initial_value=0,
+        values=values,
+    )
+
+    print(sf._data)
+    print(s1(date_func)._data)
+    assert sf.identical(s1(date_func))


### PR DESCRIPTION
…ware DatetimeIndex on `values` argument  (#GH145)

- [x] closes #145 
- [x] tests added / passed
- [x] ensure all linting tests pass
- [x] changelog entry
