### PR TITLE
StairsAccessor throwing TypeError instead of AttributeError

### DIFF
--- a/docs/release_notes/changelog.rst
+++ b/docs/release_notes/changelog.rst
@@ -10,6 +10,7 @@ UNRELEASED
 
 - dropped support for Python 3.6
 - bugfix for :func:`staircase.make_test_data` which failed with numpy < 1.17 (#GH80)
+- bugfix for staircase Series accessor causing errors during inspection of Series instances (#GH158)
 
 Please list new changes above this comment
 

--- a/staircase/core/arrays/accessor.py
+++ b/staircase/core/arrays/accessor.py
@@ -11,7 +11,7 @@ from staircase.util._decorators import Appender
 class StairsAccessor:
     def __init__(self, pandas_obj):
         if not isinstance(pandas_obj.dtype, StairsDtype):
-            raise TypeError(
+            raise AttributeError(
                 'sc accessor only valid for Series with Stairs dtype.  Convert using .astype("Stairs").'
             )
         self._obj = pandas_obj

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -48,5 +48,9 @@ def test_make_test_data(dates, positive_only, groups, seed):
 
 
 def test_accessor_non_Stairs_dtype():
-    with pytest.raises(TypeError):
+    with pytest.raises(AttributeError):
         pd.Series([1]).sc
+
+
+def test_accessor_inspection():
+    dir(pd.Series([1]))

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -53,4 +53,5 @@ def test_accessor_non_Stairs_dtype():
 
 
 def test_accessor_inspection():
+    # GH158
     dir(pd.Series([1]))


### PR DESCRIPTION
- [x] closes #158 
- [x] tests added / passed
- [x] ensure all linting tests pass
- [x] changelog entry
