### PR TITLE
Updated black version, and flake 8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
         args: ["--profile", "black", "--filter-files"]
         name: isort
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         exclude: ^staircase/test_data*
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8


### PR DESCRIPTION
- [X] closes #165
- [ ] tests added / passed
- [x] ensure all linting tests pass
- [ ] changelog entry

No relevant changes, I thought we would have some little style change cause the new version of black, but nothing changed, so the PR is not the greatest contribution.

Anyway, I set in the pypoetry.toml the line-lenght of black to be 88, which was already the the default, so no also not changes  there, it is black and pandas default too,  so it makes sense for this project. thought I usually like more 120 or so.